### PR TITLE
Add win-lose logic to GameManager

### DIFF
--- a/JungleGo/Assets/_Scripts/Classes/Constants.cs
+++ b/JungleGo/Assets/_Scripts/Classes/Constants.cs
@@ -28,7 +28,7 @@ public static class Constants
     public const int MaxUniqueProducts = 12;
     public const int MaxCustomerDelaySec = 10; 
     public const int MinCustomerDelaySec = 1;
-    public const int MinCustomers = 7;
+    public const int MinCustomers = 1;
     /// <summary>
     /// Number of customers added per difficulty level
     /// </summary>

--- a/JungleGo/Assets/_Scripts/Classes/Constants.cs
+++ b/JungleGo/Assets/_Scripts/Classes/Constants.cs
@@ -40,6 +40,7 @@ public static class Constants
     public const int DifficultyCap = 5;
 
     // === General Purpose ===
+    public const decimal WinThreshold = 10.0M;
     public static readonly string[] CustomerNames = {
         "Alice", "Bob", "Charlie", "David", "Eve", "Frank", "Grace", "Hannah", "Isaac", "Jane",
         "Kate", "Liam", "Mia", "Noah", "Olivia", "Paul", "Quinn", "Rose", "Samuel", "Tara",

--- a/JungleGo/Assets/_Scripts/Classes/Level.cs
+++ b/JungleGo/Assets/_Scripts/Classes/Level.cs
@@ -2,23 +2,20 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using UnityEngine;
 
-public class Level : MonoBehaviour
+public class Level
 {
     public List<Customer> Customers { get; set; }
     public int DelayBetweenCustomerSec;
     private List<string> uniqueNameList { get; set; }
-    private System.Random random { get; set; }
+    private Random random { get; set; }
    
     
     public Level (int difficulty = 1) 
     {
-        Debug.Log($"Level Generation Initiated, Difficulty {difficulty}");
-
         difficulty = Math.Max(difficulty, Constants.DifficultyCap);
         uniqueNameList = Constants.CustomerNames.ToList();
-        random = new System.Random();
+        random = new Random();
         Customers = GenerateCustomers(difficulty);
 
         // Min limit incase we want to adjust the max delay or difficulty cap later
@@ -27,8 +24,6 @@ public class Level : MonoBehaviour
 
     public void Initialize() 
     {
-        Debug.Log("Initializing level");
-
         InventoryManager.Instance.GenerateStock();     
         foreach (var customer in Customers) {
             customer.GenerateShoppingList();

--- a/JungleGo/Assets/_Scripts/Systems/GameManager.cs
+++ b/JungleGo/Assets/_Scripts/Systems/GameManager.cs
@@ -11,7 +11,7 @@ public class GameManager : MonoBehaviour
 
     internal List<Level> Levels { get; private set; }
 
-    private int _currentLevelIndex = 0;
+    private int currentLevelIndex = 0;
     private System.Random random = new System.Random();
 
     private void Awake()
@@ -38,9 +38,9 @@ public class GameManager : MonoBehaviour
     {
         // Given the limited time, let's reduce scope and randomly select a level
         // for a dynamic game experience. 
-        _currentLevelIndex = random.Next(0, Levels.Count);
-        var level = Levels[_currentLevelIndex];
-        Debug.Log("Initializing level");
+        currentLevelIndex = random.Next(0, Levels.Count);
+        var level = Levels[currentLevelIndex];
+        Debug.Log($"Initializing level {currentLevelIndex}");
         level.Initialize();
         Customers = level.Customers;
 

--- a/JungleGo/Assets/_Scripts/Systems/GameManager.cs
+++ b/JungleGo/Assets/_Scripts/Systems/GameManager.cs
@@ -25,6 +25,7 @@ public class GameManager : MonoBehaviour
             Levels = new List<Level>();
             for (int i = 1; i <= Constants.DifficultyCap; i++) {
                 Levels.Add(new Level(i));
+                Debug.Log($"Level Generation Initiated, Difficulty {i}");
             }
         }
         else
@@ -35,9 +36,11 @@ public class GameManager : MonoBehaviour
 
     public void Start()
     {
-        // Given the limited time, let's reduce scope and maybe randomly select a level
+        // Given the limited time, let's reduce scope and randomly select a level
         // for a dynamic game experience. 
+        _currentLevelIndex = random.Next(0, Levels.Count);
         var level = Levels[_currentLevelIndex];
+        Debug.Log("Initializing level");
         level.Initialize();
         Customers = level.Customers;
 

--- a/JungleGo/Assets/_Scripts/Systems/GameManager.cs
+++ b/JungleGo/Assets/_Scripts/Systems/GameManager.cs
@@ -23,7 +23,8 @@ public class GameManager : MonoBehaviour
 
             // Let's do dynamic level generation
             Levels = new List<Level>();
-            for (int i = 1; i <= Constants.DifficultyCap; i++) {
+            for (int i = 1; i <= Constants.DifficultyCap; i++) 
+            {
                 Levels.Add(new Level(i));
             }
         }
@@ -42,6 +43,7 @@ public class GameManager : MonoBehaviour
         Customers = level.Customers;
 
         StartCoroutine(CustomerStartLoop(level));
+        IsWinningScore();
     }
 
     IEnumerator CustomerStartLoop(Level level)
@@ -100,5 +102,52 @@ public class GameManager : MonoBehaviour
                 // @Iain, feel free to invoke purchase here.
             }
         });
+    }
+
+    private bool IsWinningScore()
+    {
+        var hasWon = false;
+        var CustomerSales = CalculateSales();
+        var PlayerInput = CalculatePlayerInput();
+
+        var result = (PlayerInput / CustomerSales) * 100;
+        if (result >= (100 + Constants.WinThreshold)) 
+        {
+            // TODO : Show player charged too much money
+            Debug.Log($"Result is {result}, lost because the player charged too much money.");
+        }
+        else if (result <= (100 - Constants.WinThreshold)) 
+        {
+            // TODO : Show player lost the company too much money
+            Debug.Log($"Result is {result}, lost because the player lost too much money.");
+        } else if (result == 100) {
+            hasWon = true;
+            Debug.Log("Won with a Perfect Score");
+        } else {
+            hasWon = true;
+            Debug.Log($"Result is {result}, won within the margin of error +/- {Constants.WinThreshold}%.");
+        }
+
+        return hasWon;
+    }
+
+    private decimal CalculateSales()
+    {
+        decimal total = 0.0M;
+        foreach (var customer in Customers) 
+        {
+           total += customer.Basket.Total; 
+        }
+
+        return total;
+    }
+
+    private decimal CalculatePlayerInput()
+    {
+        decimal total = 0.0M;
+        // Mock Player input for now
+        total = 100.0M;
+
+        return total;
     }
 }


### PR DESCRIPTION
As the title describes, GameManager now has a CoroutineCallback that currently handles the win/lose logic. We will want to consider how the end screen works - is it part of the Callback? Or do we load it in some other way? 

Coroutines operate asynchronously with the rest of the start() function, so any logic after the call to the coroutine would not necessarily be executed in the correct order.